### PR TITLE
Fixed skipping first sprite frame

### DIFF
--- a/rt2d/sprite.cpp
+++ b/rt2d/sprite.cpp
@@ -133,6 +133,8 @@ int Sprite::frame(int f)
 
 	if (f >= w*h) {
 		_frame = 0;
+		uvoffset.x = 0;
+		uvoffset.y = 0;
 		return _frame;
 	}
 


### PR DESCRIPTION
Fixed skipping first sprite frame, when calling 'Frame(0)'