### PR TITLE
Other much  shorter way to fix modelmatrix for multiple childeren of childeren

### DIFF
--- a/rt2d/renderer.cpp
+++ b/rt2d/renderer.cpp
@@ -131,7 +131,7 @@ void Renderer::renderScene(Scene* scene)
 	glfwSwapBuffers(_window);
 }
 
-void Renderer::_renderEntity(glm::mat4& modelMatrix, Entity* entity, Camera* camera)
+void Renderer::_renderEntity(glm::mat4 modelMatrix, Entity* entity, Camera* camera)
 {
 	// multiply ModelMatrix for this child with the ModelMatrix of the parent (the caller of this method)
 	// the first time we do this (for the root-parent), modelMatrix is identity.
@@ -174,8 +174,6 @@ void Renderer::_renderEntity(glm::mat4& modelMatrix, Entity* entity, Camera* cam
 	for (child = children.begin(); child != children.end(); child++) {
 		// Transform child's children...
 		this->_renderEntity(modelMatrix, *child, camera);
-		// ...then reset modelMatrix for siblings to the modelMatrix of the parent.
-		modelMatrix = this->_getModelMatrix( (*child)->parent() );
 	}
 }
 

--- a/rt2d/renderer.h
+++ b/rt2d/renderer.h
@@ -59,7 +59,7 @@ private:
 	/// @param entity The Entity that needs rendering
 	/// @param camera The camera in case we need to cull Sprites
 	/// @return void
-	void _renderEntity(glm::mat4& modelMatrix, Entity* entity, Camera* camera);
+	void _renderEntity(glm::mat4 modelMatrix, Entity* entity, Camera* camera);
 
 	/// @brief get the modelMatrix from an Entity
 	/// @param entity The Entity we need the modelMatrix from.


### PR DESCRIPTION
This much easier way to solve the same problem works as well.

I don't really understand why you really need the reference to the modelmatrix since this was the only reason why you would reset the modelmatrix which caused the bug to happen.

Have a look at both pull requests and tell me what you think of it