### PR TITLE
Rt2dchanges

### DIFF
--- a/rt2d/texture.cpp
+++ b/rt2d/texture.cpp
@@ -202,7 +202,6 @@ int Texture::writeTGAImage(std::string filePath)
 	std::stringstream filename;
 	filename << filePath;
 	id++;
-
 	FILE *fp = fopen(filename.str().c_str(), "w");
 	if (fp == nullptr) {
 		return 0;

--- a/rt2d/texture.h
+++ b/rt2d/texture.h
@@ -178,7 +178,7 @@ public:
 	/// @brief write _pixelbuffer as image to file (tga only)
 	/// @return int 0 if failed
 	int writeTGAImage();
-	/// @brief write _pixelbuffer as image to file (tga only) using a custom filepath and filename
+	/// @brief write _pixelbuffer as image to file (tga only) using a custom filepath and filename. The function will not work if the given directory does not exist.
 	/// @return int 0 if failed
 	int Texture::writeTGAImage(std::string filePath);
 	/// @brief create a width x height white PixelBuffer & GLpixeldata

--- a/rt2d/texture.h
+++ b/rt2d/texture.h
@@ -178,6 +178,9 @@ public:
 	/// @brief write _pixelbuffer as image to file (tga only)
 	/// @return int 0 if failed
 	int writeTGAImage();
+	/// @brief write _pixelbuffer as image to file (tga only) using a custom filepath and filename
+	/// @return int 0 if failed
+	int Texture::writeTGAImage(std::string filePath);
 	/// @brief create a width x height white PixelBuffer & GLpixeldata
 	/// @param width the width of the white Texture
 	/// @param height the height of the white Texture


### PR DESCRIPTION
Hey Rik,

I added an alternative writeTGAImage function in order to allow for easier file saving.

The file path will be checked for ending with .tga

The directory should always exist before running.

Specifics are documented above the function and there should be no influence on any older implementations of the function.